### PR TITLE
Page name is mandatory (fixes #4)

### DIFF
--- a/tlcr.cr
+++ b/tlcr.cr
@@ -15,7 +15,7 @@ parser = OptionParser.new do |parser|
   parser.on("-r", "--render", "Render local file (for authors)") { local = true }
   parser.on("-h", "--help", "Show this help") { Tlcr.fail parser }
   parser.unknown_args do |args|
-    Tlcr.fail parser if args.size > 1
+    Tlcr.fail parser if args.size != 1
     command = args.first?
   end
 end


### PR DESCRIPTION
A page name must be passed always (except `-h`).
