### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/src/tlcr/download.cr
+++ b/src/tlcr/download.cr
@@ -2,7 +2,7 @@ require "uri"
 
 module Tlcr
   class Download
-    ARCHIVE_URI = URI.parse("https://github.com/tldr-pages/tldr/archive/master.tar.gz")
+    ARCHIVE_URI = URI.parse("https://github.com/tldr-pages/tldr/archive/main.tar.gz")
     INDEX_URI   = URI.parse("https://tldr-pages.github.io/assets/index.json")
 
     def self.download(cache)

--- a/src/tlcr/http.cr
+++ b/src/tlcr/http.cr
@@ -14,7 +14,7 @@ module Tlcr
     end
 
     def page_content(command : Tlcr::Command)
-      ::HTTP::Client.get(@base_uri.to_s + "/master/pages/#{command.default_platform}/#{command.name}.md").body
+      ::HTTP::Client.get(@base_uri.to_s + "/main/pages/#{command.default_platform}/#{command.name}.md").body
     end
   end
 end

--- a/src/tlcr/render.cr
+++ b/src/tlcr/render.cr
@@ -17,7 +17,7 @@ module Tlcr
   end
 
   # NOTE: This is not a general purpose Markdown text renderer.
-  # It's very coupled to the conventions in https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md
+  # It's very coupled to the conventions in https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
   # It renders stuff according to the specific meanings mentioned there and ignores everything else
   class Renderer
     include Markdown::Renderer


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).